### PR TITLE
Fix travis script command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - ./configure
 
 script:
-    - py.test -n 2 -vvs
+    - bin/py.test -n 2 -vvs
 
 notifications:
     irc:


### PR DESCRIPTION
The travis build fails, because it can't find py.test. Using
"bin/py.test" instead should fix this.

Signed-off-by: Michael Rupprecht mail.michaelrupprecht@gmail.com