### PR TITLE
#7 Fix TypeError: cannot concatenate 'str' and 'type' objects

### DIFF
--- a/src/compiledcode/dwarf3.py
+++ b/src/compiledcode/dwarf3.py
@@ -96,7 +96,7 @@ def get_source_file_path_references(location):
                 unique_paths.add(path)
     except Exception as lde:
         msg = str(lde)
-        errors.append(str)
+        errors.append(msg)
 
     seen_file_names = set(file_name(p) for p in unique_paths)
     for fn in unique_files:


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes [Failed unittest for compiledcode\dwarf3.py #7](https://github.com/nexB/scancode-toolkit-contrib/issues/7)

**What does this implement/fix? Explain your changes.**

In compiledcode\dwarf3.py, a unittest failed with the following error message:
```
for error in errors:
>           yield 'ERROR: ' + error
E           TypeError: cannot concatenate 'str' and 'type' objects

src\compiledcode\dwarf3.py:107: TypeError
```

There was a typo in the code, as shown below.
```
except Exception as lde:
        msg = str(lde)
        errors.append(str)
```

which ought to be 
```
except Exception as lde:
        msg = str(lde)
        errors.append(msg)
```